### PR TITLE
Set source and target version to allow Java 11 build successfully

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <version>1.0-SNAPSHOT</version>
     <name>Maven Basic</name>
 
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -17,6 +18,10 @@
     </dependencies>
 
     <properties>
+        <!-- Needed to compile on Java 11 -->
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
     <version>1.0-SNAPSHOT</version>
     <name>Maven Basic</name>
 
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Add the source and target versions to 1.6 to allow Java 11 to build successfully. It's needed when building from a Jenkins instance running on Java 11.